### PR TITLE
feat: add a `.dockerignore` file #0000

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+docker
+docs
+.dockerignore
+.editorconfig
+.gitignore
+CONTRIBUTING.md
+Dockerfile
+README.md


### PR DESCRIPTION
Add a `.dockerignore` file, so the Dockerfile's `COPY` calls do not copy files irrelevant for the Ansible run.

Saves about 1-2MB off the image size.